### PR TITLE
App data service

### DIFF
--- a/app/services/app-data.ts
+++ b/app/services/app-data.ts
@@ -1,0 +1,63 @@
+import Service from '@ember/service';
+import {
+  BaseDirectory,
+  createDir,
+  exists,
+  readTextFile,
+  writeTextFile,
+} from '@tauri-apps/api/fs';
+import { dirname } from '@tauri-apps/api/path';
+import { appWindow } from '@tauri-apps/api/window';
+
+export class AppDataService extends Service {
+  private _debug: boolean = true;
+  private dir: number = BaseDirectory.AppData;
+
+  async load(file: string) {
+    this.debug('load', file);
+
+    file = this.prependWindowLabel(file);
+    const ok = await exists(file, { dir: this.dir });
+    if (!ok) {
+      return;
+    }
+    return await readTextFile(file, { dir: this.dir });
+  }
+
+  async save(file: string, content: string) {
+    this.debug('save', file);
+
+    file = this.prependWindowLabel(file);
+    await this.ensureDirectory(file);
+    return await writeTextFile(file, content, { dir: this.dir });
+  }
+
+  private async ensureDirectory(path: string) {
+    this.debug('ensureDirectory', path);
+
+    path = await dirname(path);
+    const ok = await exists(path, { dir: this.dir });
+    if (!ok) {
+      await createDir(path, { dir: this.dir, recursive: true });
+    }
+  }
+
+  private prependWindowLabel(file: string) {
+    return `${appWindow.label}/${file}`;
+  }
+
+  private debug(...args: any[]) {
+    if (this._debug) {
+      console.log(...args);
+    }
+  }
+}
+
+export default AppDataService;
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your services.
+declare module '@ember/service' {
+  interface Registry {
+    'app-data': AppDataService;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@tauri-apps/cli": "^1.5.5",
     "@tsconfig/ember": "^3.0.1",
     "@types/qrcode": "^1.5.4",
+    "@types/qunit": "^2.19.8",
     "@types/rsvp": "^4.0.6",
     "@types/uuid": "^9.0.6",
     "@typescript-eslint/eslint-plugin": "^6.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ devDependencies:
   '@types/qrcode':
     specifier: ^1.5.4
     version: 1.5.4
+  '@types/qunit':
+    specifier: ^2.19.8
+    version: 2.19.8
   '@types/rsvp':
     specifier: ^4.0.6
     version: 4.0.6
@@ -2766,6 +2769,10 @@ packages:
 
   /@types/qs@6.9.9:
     resolution: {integrity: sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg==}
+    dev: true
+
+  /@types/qunit@2.19.8:
+    resolution: {integrity: sha512-L4JyeRG1CJGSzJKd1b78DX/ll91E8e50IXkkl8KzW6W0IWz6FTHWEYvTEi8QVNHkUqUu6hjTffwV7ffxcoka0g==}
     dev: true
 
   /@types/range-parser@1.2.6:
@@ -10012,6 +10019,7 @@ packages:
   /node-gyp-build-optional-packages@5.0.3:
     resolution: {integrity: sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==}
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
     "allowlist": {
       "all": true,
       "fs": {
-        "scope": ["$APPCONFIG/*"]
+        "scope": ["$APPCONFIG/*", "$APPDATA/**/*"]
       }
     },
     "bundle": {

--- a/tests/unit/services/app-data-test.ts
+++ b/tests/unit/services/app-data-test.ts
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | app-data', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:app-data');
+    assert.ok(service);
+  });
+});

--- a/tests/unit/services/game-test.ts
+++ b/tests/unit/services/game-test.ts
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | game', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:game');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
A service we can use to read and write from `BaseDirectory.AppData`. It ensures that the files are located in `appWindow.label` e.g. `flimmerkasten-1`.